### PR TITLE
fix(boxPlot): Wide scatter for constant y

### DIFF
--- a/+iosr/+statistics/boxPlot.m
+++ b/+iosr/+statistics/boxPlot.m
@@ -108,7 +108,7 @@ classdef (CaseInsensitiveProperties = true) boxPlot < iosr.statistics.statsPlot
 %                             IOSR.STATISTICS.QUANTILE.
 %       notch               - Logical value indicating whether the box
 %                             should have a notch. The notch is centred on
-%                             the median and extends to ±1.58*IQR/sqrt(N),
+%                             the median and extends to Â±1.58*IQR/sqrt(N),
 %                             where N is the sample size (number of non-NaN
 %                             rows in Y). Generally if the notches of two
 %                             boxes do not overlap, this is evidence of a
@@ -2349,7 +2349,7 @@ classdef (CaseInsensitiveProperties = true) boxPlot < iosr.statistics.statsPlot
             try
                 maxDisplacement = interp1(xd, d, y);
             catch
-                maxDisplacement = zeros(size(y));
+                maxDisplacement = ones(size(y));
             end
             randOffset = rand(size(y));%randperm(numel(y))-1;
             randOffset = (2*randOffset) - 1;


### PR DESCRIPTION
When kernelDensity interpolation fails, it is because all values in y are the same. In such cases, it is desired to have maximum possible horizontal spread of samples in the scatter (as it would have if all but one value in y are the same, or values in y are close together). Thus, maxDisplacement should be 1, not 0, in the catch clause.

Fixes #14